### PR TITLE
Fixes for RT Kernel

### DIFF
--- a/capdl-loader-app/src/main.c
+++ b/capdl-loader-app/src/main.c
@@ -1129,12 +1129,13 @@ static void init_tcb(CDL_Model *spec, CDL_ObjID tcb)
     }
 
     error = seL4_TCB_SetSchedParams(sel4_tcb, seL4_CapInitThreadTCB, max_priority, priority);
-#endif
 
     ZF_LOGF_IFERR(error, "");
 
 #if CONFIG_MAX_NUM_NODES > 1
     error = seL4_TCB_SetAffinity(sel4_tcb, affinity);
+#endif
+
 #endif
 
     ZF_LOGF_IFERR(error, "");

--- a/python-capdl-tool/capdl/Allocator.py
+++ b/python-capdl-tool/capdl/Allocator.py
@@ -160,7 +160,8 @@ class ObjectAllocator(object):
         elif type == ObjectType.seL4_SchedContextObject:
             o = SC(name)
         elif type == ObjectType.seL4_SchedControl:
-            o = SchedControl(name)
+            core = kwargs.get('core', 0)
+            o = SchedControl(name, core)
         elif type == ObjectType.seL4_RTReplyObject:
             o = RTReply(name)
         elif type == ObjectType.seL4_ARMSID:


### PR DESCRIPTION
This PR has two commits, both centered around the RT Kernel.

1st, it allows CAmkES uses to set components and threads to secondary cores using the built-in `.affinity` method.

2nd, it fixes a python bug that always printed out a scheduling control cap as Core 0. This prints properly in the `.cdl`; however, the actual cdl -> c array translation using Haskell still always assigns the capability to the default core, because the `PrintC.hs` file doesn't use the passed in core parameter.

I fixed this (grossly) by doing:
```
+showCap _ (SchedControlCap core) _ _ _ =
+    "{.type = CDL_SchedControlCap, .core = " ++ show core ++ "}"
```

And adding `unsigned core` to the `CDL_Cap` structure in `capdl.h`. This allowed me to reference the core in `CDL_SchedControl_Core` with `return obj->slots.slot->cap.core;`. This is a gross way to do it. In my opinion, it should be added to the existing core parameter in the `CDL_Object`, but that required a lot more Haskell changes than I was able to handle.