### PR TITLE
capDL: updates for smmuv2 functionality

### DIFF
--- a/capDL-tool/CapDL/State.hs
+++ b/capDL-tool/CapDL/State.hs
@@ -406,6 +406,7 @@ validCapArch X86_64 (IOSpaceCap {}) = True
 validCapArch X86_64 (IOPTCap {}) = True
 validCapArch X86_64 (VCPUCap {}) = True
 validCapArch ARM11 (ARMIOSpaceCap {}) = True
+validCapArch AARCH64 (ARMIOSpaceCap {}) = True
 validCapArch AARCH64 (PUDCap {}) = True
 validCapArch AARCH64 (PGDCap {}) = True
 validCapArch _ _ = False
@@ -460,6 +461,7 @@ validObjArch X86_64 (IOAPICIrq {}) = True
 validObjArch X86_64 (MSIIrq {}) = True
 validObjArch AARCH64 (PUD {}) = True
 validObjArch AARCH64 (PGD {}) = True
+validObjArch AARCH64 (ARMIODevice {}) = True
 validObjArch _ _ = False
 
 checkObjArch :: Arch -> KernelObject Word -> ObjID -> Logger Bool

--- a/capdl-loader-app/src/main.c
+++ b/capdl-loader-app/src/main.c
@@ -1808,8 +1808,12 @@ static void init_cnode_slot(CDL_Model *spec, init_cnode_mode mode, CDL_ObjID cno
 #endif
 #if defined(CONFIG_ARCH_ARM)
     case CDL_ARMIOSpaceCap:
+#ifdef CONFIG_ARM_SMMU_V2
+        src_index = first_arm_iospace;
+#else
         src_index = first_arm_iospace + target_cap_data;
         target_cap_data = seL4_NilData;
+#endif
         break;
 #endif
     case CDL_IRQHandlerCap:


### PR DESCRIPTION
This commit allows for aarch64 to get IO Space caps. If SMMUv2 is defined, the master IOSpace Capability (which is in the first slot of the armiospace caps in bootinfo) is minted with the configured streamID.

This won't work without this PR being merged in: https://github.com/seL4/seL4/pull/148

And as an example of functionality in the VMM, the configuration needs to be updated with `vm0.smmu = [<STREAM_ID>];`. So I was able to get ethernet function on the zcu102 by passing through 0x877.