### PR TITLE
Trivial: Fix Python syntax warnings when capdl_linker.py is invoked

### DIFF
--- a/cdl_utils/capdl_linker.py
+++ b/cdl_utils/capdl_linker.py
@@ -110,7 +110,7 @@ def main():
     args = parser.parse_args()
     register_object_sizes(yaml.load(args.object_sizes, Loader=yaml.FullLoader))
 
-    if args.which is "build_cnode":
+    if args.which == "build_cnode":
         data = yaml.load(args.manifest_in, Loader=yaml.FullLoader)
         assert 'cap_symbols' in data and 'region_symbols' in data, "Invalid file format"
         elfs = [item for sublist in args.elffile for item in sublist]
@@ -119,7 +119,7 @@ def main():
         manifest(data['cap_symbols'], data['region_symbols'], args.architecture, targets)
         return 0
 
-    if args.which is "gen_cdl":
+    if args.which == "gen_cdl":
         if args.static_alloc and not args.untyped:
             parser.error('--static-alloc requires --untyped')
 


### PR DESCRIPTION
Good day,

currently, every time the linker is invoked when running from [the Docker setup](https://docs.sel4.systems/projects/dockerfiles/) it prints a syntax warning [0]. This is a bit jarring and easily avoided.

In this case we are just comparing against a string and don't actually want to check the identity. Basically, `==` is for comparing values and `is` is for comparing identities. It just happens to work in Python either way as strings are immutable.

[0]
```
$ ninja
[3/8] Generating spec.cdl
/host/projects/capdl/cdl_utils/capdl_linker.py:113: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if args.which is "build_cnode":
/host/projects/capdl/cdl_utils/capdl_linker.py:122: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if args.which is "gen_cdl":
[4/8] Generate CPIO archive capdl-loader_archive.o
```

Thanks!
