### PR TITLE
cmake: use SEL4_CMAKE_TOOL_DIR for PLATFORM_SIFT

### DIFF
--- a/capdl-loader-app/README.md
+++ b/capdl-loader-app/README.md
@@ -9,13 +9,13 @@
 This repository contains the capDL initialiser for seL4.
 
 The capDL initialiser is the root task for a seL4 system that takes a
-description of the state to be initialised using [capDL][capDL paper],
+description of the state to be initialised using [capDL][Kuz_KLW_10],
 and starts the system in conformance with the specification.
 
 The code is an implementation of the formal algorithm specified
 in Isabelle/HOL.
 
-  [capDL paper]: http://www.ssrg.nicta.com.au/publications/papers/Kuz_KLW_10.pdf "capDL: A language for describing capability-based systems"
+  [Kuz_KLW_10]: https://ts.data61.csiro.au/publications/nicta_full_text/3679.pdf "capDL: A language for describing capability-based systems"
 
 ## Repository overview
 

--- a/capdl-loader-app/helpers.cmake
+++ b/capdl-loader-app/helpers.cmake
@@ -28,10 +28,16 @@ function(BuildCapDLApplication)
     )
 
     if(DEFINED platform_yaml)
-        set(
-            PLATFORM_SIFT
-            "${CMAKE_SOURCE_DIR}/../../tools/seL4/cmake-tool/helpers/platform_sift.py"
-        )
+
+        find_file(PLATFORM_SIFT platform_sift.py PATHS ${CMAKE_MODULE_PATH} NO_CMAKE_FIND_ROOT_PATH)
+        mark_as_advanced(FORCE PLATFORM_SIFT)
+        if("${PLATFORM_SIFT}" STREQUAL "PLATFORM_SIFT-NOTFOUND")
+            message(
+                FATAL_ERROR
+                    "Failed to find platform_sift.py. Consider using -DPLATFORM_SIFT=/path/to/file"
+            )
+        endif()
+
         set(
             MEMORY_REGIONS
             "${CMAKE_BINARY_DIR}/capdl/capdl-loader-app/gen_config/capdl_loader_app/platform_info.h"


### PR DESCRIPTION
Make PLATFORM_SIFT agnostic of the build system directory layout

Note that this patch is on top of https://github.com/seL4/capdl/pull/15, if this get's merged the other PR #15 is obsolete. 