### PR TITLE
capdl-loader-app: improve log output

### DIFF
--- a/capdl-loader-app/src/main.c
+++ b/capdl-loader-app/src/main.c
@@ -2082,6 +2082,12 @@ static void init_system(CDL_Model *spec)
     init_tcbs(spec);
     init_cspace(spec);
     start_threads(spec);
+
+    ZF_LOGD("%d of %d CSlots used (%.2LF%%)", get_free_slot(),
+            BIT(CONFIG_ROOT_CNODE_SIZE_BITS),
+            ((long double)get_free_slot() / BIT(CONFIG_ROOT_CNODE_SIZE_BITS))
+            * 100);
+
 }
 
 #ifdef CONFIG_DEBUG_BUILD
@@ -2105,12 +2111,8 @@ static void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_bootinfo(void)
 
 int main(void)
 {
-    ZF_LOGD("Starting Loader...");
+    ZF_LOGI("Starting CapDL Loader...");
     init_system(&capdl_spec);
-
-    ZF_LOGD("We used %d CSlots (%.2LF%% of our CNode)", get_free_slot(),
-            (long double)get_free_slot() /
-            (long double)(BIT(CONFIG_ROOT_CNODE_SIZE_BITS) * 100));
-    ZF_LOGD(A_RESET A_FG_G "Done; suspending..." A_RESET "");
+    ZF_LOGI(A_RESET A_FG_G "CapDL Loader done, suspending..." A_RESET "");
     seL4_TCB_Suspend(seL4_CapInitThreadTCB);
 }


### PR DESCRIPTION
Make the log output a bit nicer

* Use log level INFO for CapDL Loader's start/end message and mention explicitly, that this is the CapDL loader. This turned out to be quite useful in various test cases, as it give some nice messages to check for when trying to determine if the system startup worked well at least. Having this at the INFO level allows the same mechanisms to work still for build with reduced log output.
* Move printing a message about the used capability slots to the init_system function. It seems to be better placed there and this keeps the main function slim. 

**Question**: is printing the number of use slot something that should be INFO also? We had some issues where the slots were almost exhausted and then it depends on each build's memory layout if the system fits in or not. This gave people strange "sporadic" error they could not really explain. So the message is quite helpful and it could even become a WARNING when a threshold (95%? 99%? less than 100 free slots?) is reached. 
Actually, having a static check that runs as part of the build would be nice here. Could even be a hack that just starts a QEMU to execute the loader for platform that are supported. 

