### PR TITLE
capdl-loader-app: add const qualifier

### DIFF
--- a/capdl-loader-app/README.md
+++ b/capdl-loader-app/README.md
@@ -29,10 +29,11 @@ containing the capDL specification to be initialised.
 
 ## Related papers
 
-The formal model for the capDL initialiser is documented in
-[ICFEM '13 paper][Boyton_13] and Andrew Boyton's PhD thesis.
+The formal model for the capDL initialiser is documented in a
+[ICFEM '13 paper][Boyton_13] and Andrew Boyton's [PhD thesis][Boyton_14].
 
-  [Boyton_13]: https://ts.data61.csiro.au/publications/nictaabstracts/Boyton:phd.abstract.pml "Formally Verified System Initialisation"
+  [Boyton_13]: https://ts.data61.csiro.au/publications/nicta_full_text/7047.pdf "Formally Verified System Initialisation"
+  [Boyton_14]: https://ts.data61.csiro.au/publications/nicta_full_text/9141.pdf "Secure architectures on a verified microkernel"
 
 ## License
 

--- a/capdl-loader-app/src/main.c
+++ b/capdl-loader-app/src/main.c
@@ -1958,7 +1958,7 @@ static void fill_frame_with_filedata(uintptr_t base, CDL_FrameFill_Element_t fra
 {
     unsigned long file_size;
     unsigned long cpio_size = _capdl_archive_end - _capdl_archive;
-    void *file = cpio_get_file(_capdl_archive, cpio_size, frame_fill.file_data_type.filename, &file_size);
+    const void *file = cpio_get_file(_capdl_archive, cpio_size, frame_fill.file_data_type.filename, &file_size);
     memcpy((void *)base + frame_fill.dest_offset, file + frame_fill.file_data_type.file_offset, frame_fill.dest_len);
 }
 


### PR DESCRIPTION
The recent library updates add the const qualifiers where possible, so we have to add it here also to avoid compiler warnings.
See
- https://github.com/seL4/util_libs/pull/73
- https://github.com/seL4/seL4_libs/pull/29