### PR TITLE
cdl_utils: provide yaml loader

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '2.x', '3.x' ]
+        python-version: [ '2.x', '3.9' ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2

--- a/cdl_utils/untyped_gen.py
+++ b/cdl_utils/untyped_gen.py
@@ -114,8 +114,8 @@ def get_symbol_size(elf, name):
 
 def main(args):
     arch = lookup_architecture(args.architecture)
-    addresses = yaml.load(args.input)
-    object_sizes = yaml.load(args.object_sizes)
+    addresses = yaml.load(args.input, loader=yaml.FullLoader)
+    object_sizes = yaml.load(args.object_sizes, loader=yaml.FullLoader)
     register_object_sizes(object_sizes)
 
     # create the list of reserved regions. This duplicates the load_images part of the elf loader. Ultimately


### PR DESCRIPTION
These are needed for the more recent python install in the new docker environment.

- PyYAML > 5.1 requires a loader argument
- make sure GitHub tests use at most python 3.9 (as in docker container). Python 3.10 doesn't work, because `nose` breaks.
