### PR TITLE
capDL-tool: get ghc802 from old nixpkgs on nixos

### DIFF
--- a/capDL-tool/shell.nix
+++ b/capDL-tool/shell.nix
@@ -1,0 +1,19 @@
+#
+# Copyright 2022, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+with import
+  (builtins.fetchGit {
+    # Descriptive name to make the store path easier to identify
+    name = "nixos-18.09";
+    url = "https://github.com/nixos/nixpkgs/";
+    # `git ls-remote https://github.com/nixos/nixpkgs nixos-unstable`
+    ref = "refs/heads/nixos-18.09";
+    rev = "a7e559a5504572008567383c3dc8e142fa7a8633";
+  })
+{ };
+mkShell {
+  buildInputs = [ haskell.compiler.ghc802 ];
+}

--- a/capDL-tool/stack.yaml
+++ b/capDL-tool/stack.yaml
@@ -8,3 +8,5 @@
 resolver: lts-9.21
 
 local-bin-path: .
+nix:
+  shell-file: shell.nix


### PR DESCRIPTION
Building capDL-tool on NixOS gives an error since stack uses custom logic on NixOS which tries to fetch a version of ghc that no longer exists on nixpkgs, the package repository for NixOS. This should not affect non-NixOS stack users.

Signed-off-by: Kevin Tran <z5164322@unsw.edu.au>