### PR TITLE
capdl-loader-app: ensure heap is aligned

### DIFF
--- a/capdl-loader-app/src/main.c
+++ b/capdl-loader-app/src/main.c
@@ -2106,14 +2106,13 @@ static void init_system(CDL_Model *spec)
  * for stdin, stdout, and stderr. */
 extern char *morecore_area;
 extern size_t morecore_size;
-#define DEBUG_LIBC_MORECORE_SIZE 4096
-static char debug_libc_morecore_area[DEBUG_LIBC_MORECORE_SIZE];
+static char debug_libc_morecore_area[PAGE_SIZE_4K];
 
 static void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_bootinfo(void)
 {
     /* Init memory area for musl. */
     morecore_area = debug_libc_morecore_area;
-    morecore_size = DEBUG_LIBC_MORECORE_SIZE;
+    morecore_size = sizeof(debug_libc_morecore_area);
 
     /* Allow us to print via seL4_Debug_PutChar. */
     platsupport_serial_setup_bootinfo_failsafe();

--- a/capdl-loader-app/src/main.c
+++ b/capdl-loader-app/src/main.c
@@ -2103,10 +2103,12 @@ static void init_system(CDL_Model *spec)
 
 #ifdef CONFIG_DEBUG_BUILD
 /* We need to give malloc enough memory for musllibc to allocate memory
- * for stdin, stdout, and stderr. */
+ * for stdin, stdout, and stderr. The heap pool base address and size is
+ * expected to be page aligned.
+ */
 extern char *morecore_area;
 extern size_t morecore_size;
-static char debug_libc_morecore_area[PAGE_SIZE_4K];
+static char ALIGN(PAGE_SIZE_4K) debug_libc_morecore_area[PAGE_SIZE_4K];
 
 static void CONSTRUCTOR(MUSLCSYS_WITH_VSYSCALL_PRIORITY) init_bootinfo(void)
 {


### PR DESCRIPTION
Align with recent changes that expect page alignment.
See https://github.com/seL4/seL4_libs/pull/63

It seems the heap is never used, so we could also consider removing it completely. I'm only running into issues if I add more alignment checks in the heap management. Thus adding the alignment here seems a good choice.