### PR TITLE
Support specifying rights for fault handler caps

### DIFF
--- a/capdl-loader-app/include/capdl.h
+++ b/capdl-loader-app/include/capdl.h
@@ -473,6 +473,14 @@ static inline seL4_CapRights_t CDL_seL4_Cap_Rights(CDL_Cap *cap)
                               !!(cap->rights & CDL_CanWrite));
 }
 
+static inline uint32_t CONST seL4_CapRights_get_capAllowAllRights(seL4_CapRights_t seL4_CapRights)
+{
+    return (seL4_CapRights_get_capAllowRead(seL4_CapRights) &&
+            seL4_CapRights_get_capAllowWrite(seL4_CapRights) &&
+            seL4_CapRights_get_capAllowGrant(seL4_CapRights) &&
+            seL4_CapRights_get_capAllowGrantReply(seL4_CapRights));
+}
+
 static inline const char *CDL_Obj_Name(CDL_Object *obj)
 {
 #ifdef CONFIG_DEBUG_BUILD

--- a/python-capdl-tool/capdl/Object.py
+++ b/python-capdl-tool/capdl/Object.py
@@ -396,6 +396,8 @@ class TCB(ContainerObject):
 
 # untypeds are ordered by their paddr, then size, then name, which makes allocation of objects from an
 # untyped at specific addresses easier.
+
+
 @total_ordering
 class Untyped(Object):
     def __init__(self, name, size_bits=12, paddr=None):

--- a/python-capdl-tool/capdl/Object.py
+++ b/python-capdl-tool/capdl/Object.py
@@ -370,12 +370,25 @@ class TCB(ContainerObject):
     def set_affinity(self, affinity):
         self.affinity = affinity
 
-    def set_fault_ep_slot(self, fault_ep_slot=0, fault_ep=None, badge=0):
+    def set_fault_ep_slot(self, fault_ep_slot=0, fault_ep=None, badge=0, rights=ObjectRights.seL4_AllRights):
         if fault_ep_slot != 0:
             self.fault_ep_slot = fault_ep_slot
         if fault_ep:
+            fields = []
             if badge != 0:
-                fault_ep += " (badge: %d)" % badge
+                fields += ['badge: %d' % badge]
+            rights_list = [
+                sym for sym, right in [
+                    ('R', ObjectRights.seL4_CanRead),
+                    ('W', ObjectRights.seL4_CanWrite),
+                    ('G', ObjectRights.seL4_CanGrant),
+                    ('P', ObjectRights.seL4_CanGrantReply)
+                ] if right in rights
+            ]
+            if rights_list:
+                fields += [''.join(rights_list)]
+            if fields:
+                fault_ep += ' (' + ','.join(fields) + ')'
             self.__setitem__("fault_ep_slot", fault_ep)
 
     def get_size_bits(self):


### PR DESCRIPTION
This updates the python-capdl-tool and capdl-loader-app to support specifying the rights for fault handler caps on realtime systems.

The python-capdl-tool defaults to seL4_AllRights, which results in the same behaviour as before.