### PR TITLE
loader mcs: set handler params with TCB syscalls

### DIFF
--- a/capdl-loader-app/include/capdl.h
+++ b/capdl-loader-app/include/capdl.h
@@ -473,14 +473,6 @@ static inline seL4_CapRights_t CDL_seL4_Cap_Rights(CDL_Cap *cap)
                               !!(cap->rights & CDL_CanWrite));
 }
 
-static inline uint32_t CONST seL4_CapRights_get_capAllowAllRights(seL4_CapRights_t seL4_CapRights)
-{
-    return (seL4_CapRights_get_capAllowRead(seL4_CapRights) &&
-            seL4_CapRights_get_capAllowWrite(seL4_CapRights) &&
-            seL4_CapRights_get_capAllowGrant(seL4_CapRights) &&
-            seL4_CapRights_get_capAllowGrantReply(seL4_CapRights));
-}
-
 static inline const char *CDL_Obj_Name(CDL_Object *obj)
 {
 #ifdef CONFIG_DEBUG_BUILD


### PR DESCRIPTION
Instead of minting new endpoint caps with the required badge and rights, we use seL4_TCB_SetSchedParams and seL4_TCB_SetTimeoutEndpoint to set them for us.