### PR TITLE
object_sizes: Add include for deprecated constants

### DIFF
--- a/object_sizes/object_sizes.yaml
+++ b/object_sizes/object_sizes.yaml
@@ -3,6 +3,7 @@
 #include <autoconf.h>
 #include <sel4/constants.h>
 #include <sel4/sel4_arch/constants.h>
+#include <sel4/sel4_arch/deprecated.h>
 #include <sel4/mode/types.h>
 seL4_TCBObject: seL4_TCBBits
 seL4_EndpointObject: seL4_EndpointBits


### PR DESCRIPTION
Some definitions that object_sizes depends on are now found in a deprecated.h header file.

Because object_sizes generates a yaml file, it can't only include <sel4/sel4.h> because of incompatible C source definitions.