### PR TITLE
aarch64: Minimal update for vspace API change

### DIFF
--- a/capdl-loader-app/include/capdl.h
+++ b/capdl-loader-app/include/capdl.h
@@ -169,7 +169,9 @@ typedef enum {
     CDL_Frame         = seL4_ARM_SmallPageObject,
 #ifdef CONFIG_ARCH_AARCH64
     CDL_PUD           = seL4_ARM_PageUpperDirectoryObject,
+#if !(defined(CONFIG_ARM_HYPERVISOR_SUPPORT) && defined (CONFIG_ARM_PA_SIZE_BITS_40))
     CDL_PGD           = seL4_ARM_PageGlobalDirectoryObject,
+#endif
 #endif
 #ifdef CONFIG_ARM_HYPERVISOR_SUPPORT
     CDL_VCPU          = seL4_ARM_VCPUObject,


### PR DESCRIPTION
The aarch64 vspace API is changed to only have a single pagetable object and capability type for all intermediate page table levels. The root vspace object is still a separate object and capability type.

As part of this change, seL4_ARM_PageGlobalDirectoryObject is no longer defined for configurations where it was previously an invalid object. This causes some minor breakages which this commit addresses.