### PR TITLE
upgrade GH actions + test python 3.9 in addition to latest python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.x' ]
+        python-version: [ '3.9', '3.x' ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
     - run: |
         sudo apt-get update
         sudo apt-get install libxml2-utils
-    - uses: actions/setup-haskell@v1.1.4
+    - uses: haskell/actions/setup@v2
       with:
         enable-stack: true
         stack-setup-ghc: true


### PR DESCRIPTION
https://github.com/seL4/capdl/pull/55 did most of what this PR initially tried to do. What is left is:

- switch to official Haskell action for stack/ghc setup
- explicitly add python 3.9 to the test, because that's the version in docker (but keep 3.x, i.e. latest python)
