### PR TITLE
python-capdl-tool: Update python3 test scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '2.x', '3.9' ]
+        python-version: [ '3.x' ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -41,12 +41,11 @@ jobs:
     - name: Install python packages
       run: |
         cd python-capdl-tool
-        pip install -r requirements.txt
-        pip install nose future
+        pip3 install -r requirements.txt
     - name: Run tests
       run: |
         cd python-capdl-tool/tests
-        nosetests --exe
+        PYTHONPATH=../ ./runall.py
 
   capDL-tool:
     name: capDL-tool (ghc)

--- a/python-capdl-tool/requirements.txt
+++ b/python-capdl-tool/requirements.txt
@@ -1,14 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #
 # SPDX-License-Identifier: BSD-2-Clause
 #
 aenum
-orderedset
+ordered-set
 pyelftools
 six
 sortedcontainers
 concurrencytest
 hypothesis
-nose
+future

--- a/python-capdl-tool/tests/__init__.py
+++ b/python-capdl-tool/tests/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #

--- a/python-capdl-tool/tests/allocator.py
+++ b/python-capdl-tool/tests/allocator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #

--- a/python-capdl-tool/tests/runall.py
+++ b/python-capdl-tool/tests/runall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)

--- a/python-capdl-tool/tests/testelf.py
+++ b/python-capdl-tool/tests/testelf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #

--- a/python-capdl-tool/tests/testmerge.py
+++ b/python-capdl-tool/tests/testmerge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
 #


### PR DESCRIPTION
.github action runners can just run tests with python3 only now.

Addresses https://github.com/seL4/capdl/issues/31