### PR TITLE
github: bump GitHub action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     name: Language Spec PDF
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install texlive and pandoc
       run: |
         sudo apt-get update
@@ -34,8 +34,8 @@ jobs:
         python-version: [ '3.x' ]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install python packages
@@ -51,7 +51,7 @@ jobs:
     name: capDL-tool (ghc)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: |
         sudo apt-get update
         sudo apt-get install libxml2-utils


### PR DESCRIPTION
Update to current node16 versions. The old node12 actions are deprecated and will stop working.