### PR TITLE
trivial: Make capitalization more consistent

### DIFF
--- a/capdl-loader-app/include/capdl.h
+++ b/capdl-loader-app/include/capdl.h
@@ -420,7 +420,7 @@ typedef struct {
 #define CDL_TCB_Notification_Slot   8
 
 #if defined(CONFIG_ARM_HYPERVISOR_SUPPORT) || defined(CONFIG_VTX)
-#define CDL_TCB_VCPU_SLOT           9
+#define CDL_TCB_VCPU_Slot           9
 #endif
 
 #define CDL_CapData_MakeGuard(x, y) \

--- a/capdl-loader-app/src/main.c
+++ b/capdl-loader-app/src/main.c
@@ -1016,7 +1016,7 @@ static void init_tcb(CDL_Model *spec, CDL_ObjID tcb)
     CDL_Cap *cdl_notification = get_cap_at(cdl_tcb, CDL_TCB_Notification_Slot);
 
 #if defined(CONFIG_ARM_HYPERVISOR_SUPPORT) || defined(CONFIG_VTX)
-    CDL_Cap *cdl_vcpu = get_cap_at(cdl_tcb, CDL_TCB_VCPU_SLOT);
+    CDL_Cap *cdl_vcpu = get_cap_at(cdl_tcb, CDL_TCB_VCPU_Slot);
 #endif
 
     CDL_Cap *cdl_sc   = get_cap_at(cdl_tcb, CDL_TCB_SC_Slot);


### PR DESCRIPTION
https://github.com/seL4/capdl/pull/12 (authored by me - sorry) introduced an inconsistency in macro capitalization in `capdl-loader-app`. This trivial change corrects it.