### PR TITLE
undyped_gen: remove pyaml dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,8 +14,10 @@
 
 ### Changes
 
+* remove `pyaml` python dependency and use `pyyaml` (import `yaml`) directly.
 
 ### Upgrade Notes
+
 ---
 
 ## 0.3 2024-07-01

--- a/cdl_utils/untyped_gen.py
+++ b/cdl_utils/untyped_gen.py
@@ -14,7 +14,7 @@ import logging
 from collections import namedtuple, deque, defaultdict
 
 from elftools.elf.elffile import ELFFile
-from pyaml import yaml
+import yaml
 from sortedcontainers import SortedList
 
 from capdl import register_object_sizes


### PR DESCRIPTION
We only need the yaml part, and `pyaml` (Pretty Yaml) has been removed from sel4-deps in sel4-deps 0.4.0. Instead sel4-deps now has `pyyaml`, which only provides the `yaml` import.