### PR TITLE
capDL-tool: update to LTS 24.32, ghc-9.10.3

### DIFF
--- a/capDL-tool/CapDL/State.hs
+++ b/capDL-tool/CapDL/State.hs
@@ -10,6 +10,7 @@ import CapDL.Model
 
 import Prelude ()
 import Prelude.Compat
+import Control.Monad
 import Control.Monad.State
 import Control.Monad.Writer
 import Data.Maybe

--- a/capDL-tool/capDL-tool.cabal
+++ b/capDL-tool/capDL-tool.cabal
@@ -33,16 +33,16 @@ executable parse-capDL
                        -- Included libraries
                        array >=0.5 && <0.6,
                        base >= 4.16,
-                       containers >=0.6 && <0.7,
-                       filepath >=1.4 && <1.5,
-                       mtl >=2.2 && <2.3,
+                       containers >=0.7 && <0.8,
+                       filepath >=1.5 && <1.6,
+                       mtl >=2.3 && <2.4,
                        parsec >=3.1 && <3.2,
                        unix >=2.7 && <3,
 
                        -- Other libraries
-                       base-compat == 0.12.*,
-                       lens >= 4.15,
-                       MissingH >=1.4 && <1.6,
+                       base-compat == 0.14.*,
+                       lens >= 5.2,
+                       MissingH >=1.6 && <1.7,
                        pretty >=1.1 && <1.2,
                        regex-compat >= 0.90,
                        split >=0.2 && <0.3,
@@ -61,3 +61,4 @@ executable parse-capDL
                        -fno-warn-missing-signatures -fno-warn-type-defaults
                        -fno-warn-incomplete-uni-patterns
                        -fno-warn-incomplete-record-updates
+                       -fno-warn-x-partial

--- a/capDL-tool/stack.yaml
+++ b/capDL-tool/stack.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-# Stackage LTS Haskell 20.25 (ghc-9.2.8)
-resolver: lts-20.25
+# Stackage LTS Haskell 24.32 (ghc-9.10.3)
+resolver: lts-24.32
 
 local-bin-path: .


### PR DESCRIPTION
The instances of `{-# OPTIONS_GHC -Wno-x-partial #-}` throughout are to enable the continued use of functions like `head`.