### PR TITLE
python-capdl-tool: support external regions

### DIFF
--- a/python-capdl-tool/capdl/Allocator.py
+++ b/python-capdl-tool/capdl/Allocator.py
@@ -276,6 +276,7 @@ class AddressSpaceAllocator(object):
         self.name = name
         self.vspace_root = vspace_root
         self._symbols = {}
+        self._external_regions = {}
         self._regions = {}
 
     def add_symbol_with_caps(self, symbol, sizes, caps):
@@ -310,6 +311,29 @@ class AddressSpaceAllocator(object):
         symbols = self._symbols
         self._symbols = None
         return symbols
+
+    def add_external_region_with_caps(self, vaddr, sizes, caps):
+        '''
+        Specify the caps and sizes to use for a region outside of the ELF file.
+        Objects that the caps refer to should have been allocated by an
+        ObjectAllocator otherwise they might not end up in the final CDL spec
+        file.
+
+        It should be possible for the frames to be mapped into the address
+        space at the given vaddr in a sensible way. Therefore alignment of
+        vaddr should be compatible with the array of frames provided.
+        '''
+        self._external_regions[vaddr] = (sizes, caps)
+
+    def get_external_regions_and_clear(self):
+        '''
+        This function is used for converting symbols into virtual addresses with
+        an elf file. Resulting regions should be added back via add_region_with_caps
+        This sets the internal symbols structure to None to prevent usages after.
+        '''
+        external_regions = self._external_regions
+        self._external_regions = None
+        return external_regions
 
     def add_region_with_caps(self, vaddr, sizes, caps):
         '''

--- a/python-capdl-tool/capdl/ELF.py
+++ b/python-capdl-tool/capdl/ELF.py
@@ -154,6 +154,11 @@ class ELF(object):
                     "Symbol (%s:%d) must have same or greater size than supplied cap range (%d)" % (
                         symbol, self.get_symbol_size(symbol), sum(sizes))
                 existing_pages.append((self.get_symbol_vaddr(symbol), sizes, caps))
+            for (vaddr, (sizes, caps)) in iteritems(addr_space.get_external_regions_and_clear()):
+                existing_pages.append((vaddr, sizes, caps))
+                for (size, cap) in zip(sizes, caps):
+                    pages.add_page(vaddr, read=cap.read, write=cap.write, size=size)
+                    vaddr += size
 
             existing_pages.sort(key=lambda phys_addr: phys_addr[0])
             self.check_alignment(existing_pages)


### PR DESCRIPTION
Adds support for mapping caps into an address space at arbitrary addresses, outside of the bounds of the ELF file.

This adds another level of flexibility to users of this library. [`rust-sel4`](https://github.com/seL4/rust-sel4) uses this feature (currently in a branch) for a [custom CapDL-based testing framework](https://github.com/seL4/rust-sel4/tree/main/hacking/src/python/capdl_simple_composition).