### PR TITLE
python-capdl-tool: remove future package

### DIFF
--- a/python-capdl-tool/capdl/Allocator.py
+++ b/python-capdl-tool/capdl/Allocator.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import abc
 import collections
 import logging

--- a/python-capdl-tool/capdl/Cap.py
+++ b/python-capdl-tool/capdl/Cap.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from capdl.Object import Object, Frame, CNode, Endpoint, Notification, \
     SchedControl, SMC
 

--- a/python-capdl-tool/capdl/ELF.py
+++ b/python-capdl-tool/capdl/ELF.py
@@ -9,10 +9,6 @@ Functionality related to handling ELF file input. This is the only section of
 this module that relies on elftools, so it is possible to use this module
 without elftools installed by not importing this particular file.
 """
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-from future.utils import iteritems
-
 from elftools.elf.elffile import ELFFile
 from elftools.elf.constants import P_FLAGS
 from .Object import TCB
@@ -149,12 +145,12 @@ class ELF(object):
         existing_pages = []
         if addr_space:
             # Update symbols with their vaddrs in the AddressSpaceAllocator if we were given one
-            for (symbol, (sizes, caps)) in iteritems(addr_space.get_symbols_and_clear()):
+            for (symbol, (sizes, caps)) in addr_space.get_symbols_and_clear().items():
                 assert self.get_symbol_size(symbol) >= sum(sizes), \
                     "Symbol (%s:%d) must have same or greater size than supplied cap range (%d)" % (
                         symbol, self.get_symbol_size(symbol), sum(sizes))
                 existing_pages.append((self.get_symbol_vaddr(symbol), sizes, caps))
-            for (vaddr, (sizes, caps)) in iteritems(addr_space.get_external_regions_and_clear()):
+            for (vaddr, (sizes, caps)) in addr_space.get_external_regions_and_clear().items():
                 existing_pages.append((vaddr, sizes, caps))
                 for (size, cap) in zip(sizes, caps):
                     pages.add_page(vaddr, read=cap.read, write=cap.write, size=size)

--- a/python-capdl-tool/capdl/Object.py
+++ b/python-capdl-tool/capdl/Object.py
@@ -8,9 +8,6 @@
 Definitions of kernel objects.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import abc
 import math
 import six

--- a/python-capdl-tool/capdl/PageCollection.py
+++ b/python-capdl-tool/capdl/PageCollection.py
@@ -9,9 +9,6 @@ Wrapper around a dict of pages for some extra functionality. Only intended to
 be used internally.
 '''
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from .Cap import Cap
 from .Object import ASIDPool, Frame
 from .Spec import Spec

--- a/python-capdl-tool/capdl/Spec.py
+++ b/python-capdl-tool/capdl/Spec.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from .Object import IRQ, Object
 from .util import lookup_architecture, DomainDurationUnit
 

--- a/python-capdl-tool/capdl/__init__.py
+++ b/python-capdl-tool/capdl/__init__.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from .Cap import Cap
 from .ELF import ELF
 from .Object import Frame, PageTable, PageDirectory, ASIDPool, CNode, Endpoint, \

--- a/python-capdl-tool/capdl/util.py
+++ b/python-capdl-tool/capdl/util.py
@@ -8,9 +8,6 @@
 Various internal utility functions. Pay no mind to this file.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import abc
 
 from aenum import Enum

--- a/python-capdl-tool/examples/allocation.py
+++ b/python-capdl-tool/examples/allocation.py
@@ -7,9 +7,6 @@
 # The module Allocator.py contains an object and CSpace allocator. This example
 # shows how these can be used for convenience.
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 # Add the root directory of this repository to your PYTHONPATH environment
 # variable to enable the following import.
 import capdl

--- a/python-capdl-tool/examples/capdl-manipulation.py
+++ b/python-capdl-tool/examples/capdl-manipulation.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 # Add the root directory of this repository to your PYTHONPATH environment
 # variable to enable the following import.
 import capdl

--- a/python-capdl-tool/examples/construct-address-space.py
+++ b/python-capdl-tool/examples/construct-address-space.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 # Add the root directory of this repository to your PYTHONPATH environment
 # variable to enable the following import.
 import capdl

--- a/python-capdl-tool/examples/domains.py
+++ b/python-capdl-tool/examples/domains.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 # Add the root directory of this repository to your PYTHONPATH environment
 # variable to enable the following import.
 import capdl

--- a/python-capdl-tool/examples/to-capdl.py
+++ b/python-capdl-tool/examples/to-capdl.py
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 # Add the root directory of this repository to your PYTHONPATH environment
 # variable to enable the following import.
 import capdl

--- a/python-capdl-tool/requirements.txt
+++ b/python-capdl-tool/requirements.txt
@@ -11,4 +11,3 @@ six
 sortedcontainers
 concurrencytest
 hypothesis
-future

--- a/python-capdl-tool/tests/__init__.py
+++ b/python-capdl-tool/tests/__init__.py
@@ -5,9 +5,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import unittest
 
 from capdl import register_object_sizes

--- a/python-capdl-tool/tests/allocator.py
+++ b/python-capdl-tool/tests/allocator.py
@@ -5,9 +5,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import unittest
 
 import hypothesis.strategies as st

--- a/python-capdl-tool/tests/runall.py
+++ b/python-capdl-tool/tests/runall.py
@@ -10,8 +10,6 @@
 This script is a quick way to execute the tests for all capdl-python modules.
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 from concurrencytest import ConcurrentTestSuite, fork_for_tests
 
 import argparse

--- a/python-capdl-tool/tests/testelf.py
+++ b/python-capdl-tool/tests/testelf.py
@@ -5,9 +5,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import unittest
 
 from capdl import ELF

--- a/python-capdl-tool/tests/testmerge.py
+++ b/python-capdl-tool/tests/testmerge.py
@@ -5,9 +5,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import capdl
 from tests import CapdlTestCase
 


### PR DESCRIPTION
Only needed for python2/3 compatibility which is now obsolete.

There is still the compatibility package `six` left, but I need to read up on what all this metaclass stuff is that the current code is doing with it.