### PR TITLE
cdl_utils+python-capdl-tool: remove six package

### DIFF
--- a/cdl_utils/capdl_linker.py
+++ b/cdl_utils/capdl_linker.py
@@ -17,7 +17,6 @@ import logging
 import os
 import tempfile
 import yaml
-import six
 
 
 CSPACE_TEMPLATE_FILE = os.path.join(os.path.dirname(__file__), "templates/cspace.template.c")

--- a/python-capdl-tool/capdl/Allocator.py
+++ b/python-capdl-tool/capdl/Allocator.py
@@ -8,7 +8,6 @@ import abc
 import collections
 import logging
 
-import six
 from sortedcontainers import SortedList, SortedSet, SortedDict
 
 from .Cap import Cap
@@ -426,7 +425,7 @@ class ASIDTableAllocator(object):
                                          (asid_pool.name, asid_pool.asid_high, asid_pool.asid_high - 1))
 
 
-class UntypedAllocator(six.with_metaclass(abc.ABCMeta, object)):
+class UntypedAllocator(abc.ABC):
     """
     An allocation interface for assigning objects to specific untypeds.
     Each untyped allocator implements its own policy.

--- a/python-capdl-tool/capdl/ELF.py
+++ b/python-capdl-tool/capdl/ELF.py
@@ -16,7 +16,6 @@ from .util import PAGE_SIZE, round_down, page_sizes
 from .PageCollection import PageCollection
 import os
 import re
-import six
 
 
 def _decode(data):
@@ -41,7 +40,7 @@ class ELF(object):
         parameter 'elf', or a stream to ELF data. 'name' is only used when
         generating CapDL from the ELF file.
         """
-        if isinstance(elf, six.string_types):
+        if isinstance(elf, str):
             f = open(elf, 'rb')
         else:
             f = elf

--- a/python-capdl-tool/capdl/Object.py
+++ b/python-capdl-tool/capdl/Object.py
@@ -10,7 +10,6 @@ Definitions of kernel objects.
 
 import abc
 import math
-import six
 from functools import total_ordering
 
 from aenum import Enum, Flag, unique, auto, IntEnum
@@ -121,7 +120,7 @@ class ARMIRQMode(IntEnum):
     seL4_ARM_IRQ_EDGE = 1
 
 
-class Object(six.with_metaclass(abc.ABCMeta, object)):
+class Object(abc.ABC):
     """
     Parent of all kernel objects.
     """
@@ -140,7 +139,7 @@ class Object(six.with_metaclass(abc.ABCMeta, object)):
         return False
 
 
-class ContainerObject(six.with_metaclass(abc.ABCMeta, Object)):
+class ContainerObject(Object):
     """
     Common functionality for all objects that are cap containers, in the sense
     that they may have child caps.
@@ -155,9 +154,9 @@ class ContainerObject(six.with_metaclass(abc.ABCMeta, Object)):
 
     def print_contents(self):
         keys = self.slots.keys()
-        if all(isinstance(k, six.integer_types) for k in keys):
+        if all(isinstance(k, int) for k in keys):
             def print_slot_index(index): return '0x%x' % index
-        elif all(isinstance(k, six.string_types) for k in keys):
+        elif all(isinstance(k, str) for k in keys):
             def print_slot_index(index): return index
         else:
             raise RuntimeError(

--- a/python-capdl-tool/capdl/util.py
+++ b/python-capdl-tool/capdl/util.py
@@ -11,8 +11,6 @@ Various internal utility functions. Pay no mind to this file.
 import abc
 
 from aenum import Enum
-import six
-from six.moves import range
 
 from .Object import ObjectType, PageTable, PageDirectory, PML4, PDPT, PGD, PUD, get_object_size
 
@@ -86,7 +84,7 @@ def make_levels(levels):
     return levels[0]
 
 
-class Arch(six.with_metaclass(abc.ABCMeta, object)):
+class Arch(abc.ABC):
     def get_pages(self):
         level = self.vspace()
         pages = []
@@ -289,7 +287,7 @@ def last_level(level):
 
 
 def page_sizes(arch):
-    if isinstance(arch, six.string_types):
+    if isinstance(arch, str):
         arch = lookup_architecture(arch)
     list = [get_object_size(page) for page in arch.get_pages()]
     list.sort()
@@ -341,7 +339,7 @@ def ctz(size_bytes):
     The value must be greater than 0.
     """
     assert (size_bytes > 0)
-    assert (isinstance(size_bytes, six.integer_types))
+    assert (isinstance(size_bytes, int))
     low = size_bytes & -size_bytes
     low_bit = -1
     while low:

--- a/python-capdl-tool/requirements.txt
+++ b/python-capdl-tool/requirements.txt
@@ -7,7 +7,6 @@
 aenum
 ordered-set
 pyelftools
-six
 sortedcontainers
 concurrencytest
 hypothesis


### PR DESCRIPTION
Remove python2 compatibility package `six`. Main changes are:

- six.integer_types -> int
- six.string_types -> str
- six.with_metaclass(abc.ABCMeta, object) -> abc.ABC
- six.with_metaclass(abc.ABCMeta, Object) becomes Object, because Object already inherits from abc.ABC
- drop six from requirements.txt